### PR TITLE
Dropped support for Python 3.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,9 +21,9 @@ jobs:
           python-version: ${{ matrix.python }}
 
       - name: Install and configure Poetry
-        uses: snok/install-poetry@v1.1.1
+        uses: snok/install-poetry@v1
         with:
-          version: 1.1.4
+          version: 1.1.13
           virtualenvs-create: true
           virtualenvs-in-project: false
           virtualenvs-path: ~/.virtualenvs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,13 @@ version = "3.0.0"
 
 [tool.poetry.dependencies]
 Sphinx = {version = ">=3.5.3,<6.0.0", optional = true}
-httpx = ">=0.18,<0.23"
 pydantic = "^1.8.2"
-python = "^3.6.2"
-sphinx-rtd-theme = {version = ">=0.5.1,<1.1.0", optional = true}
-xmltodict = ">=0.12,<0.14"
-typing-extensions = ">=3.10,<5.0"
+python = "^3.7"
 semver = "^2.13.0"
+sphinx-rtd-theme = {version = ">=0.5.1,<1.1.0", optional = true}
+typing-extensions = ">=3.10,<5.0"
+xmltodict = ">=0.12,<0.14"
+httpx = "^0.23.0"
 
 [tool.poetry.extras]
 docs = ["Sphinx", "sphinx-rtd-theme"]
@@ -25,12 +25,12 @@ docs = ["Sphinx", "sphinx-rtd-theme"]
 bandit = "^1.7.0"
 black = "^22.1"
 isort = "^5.7.0"
+lxml = "^4.7.1"
 mypy = "^0.961"
 pylint = "^2.8.2"
-tox = "^3.23.0"
 pytest = "^7.0.0"
-lxml = "^4.7.1"
 pytest-cov = "^3.0.0"
+tox = "^3.23.0"
 
 [build-system]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
As a by-product, `httpx` can now be updated to the latest release.